### PR TITLE
Escape spaces and commas in seriesName

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,7 +253,7 @@ InfluxDB.prototype._prepareValues = function (series) {
   var output = []
   _.forEach(series, function (values, seriesName) {
     _.each(values, function (points) {
-      var line = seriesName
+      var line = seriesName.replace(/ /g, '\\ ').replace(/,/g, '\\,')
       if (points[1] && _.isObject(points[1]) && _.keys(points[1]).length > 0) {
         line += ',' + this._createKeyValueString(points[1])
       }


### PR DESCRIPTION
Escape spaces and commas in seriesName - according to https://influxdb.com/docs/v0.9/write_protocols/line.html
fix https://github.com/node-influx/node-influx/issues/62 ?